### PR TITLE
fix: 상세페이지 머지 후에러 처리

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,3 +1,4 @@
+import type { AxiosResponse } from 'axios';
 import type * as myInterface from '../assets/interfaces';
 import instance from './instance';
 
@@ -60,4 +61,3 @@ const schedule = {
 };
 
 export { login, navermap, crew, notice, searchByCategory, schedule };
-

--- a/src/assets/interfaces.ts
+++ b/src/assets/interfaces.ts
@@ -78,14 +78,14 @@ export interface VoteForm {
   crewId: number;
 }
 // 정모 공지
-export interface Notice {
+export interface CrewNotice {
   noticeTitle: string;
   noticeContent: string;
   noticeAddress: string;
   noticeDDay: string;
 }
 export interface AllNotice {
-  regularNotice: Notice[];
+  regularNotice: CrewNotice[];
   voteForm: VoteForm[];
 }
 export interface GuestDetail {
@@ -119,5 +119,3 @@ export interface SearchByCategory {
   crew_crewMaxMember: string;
   crewAttendedMember: string;
 }
-
-

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -6,9 +6,8 @@ import ScheduleCard from '../../styledComponent/ScheduleCard';
 import LargeCardLink from '../../styledComponent/LargeCardLink';
 import InterestMatrix from '../../components/common/InterestMatrix';
 import colors from '../../assets/styles/color';
-import TitleLargeBold from '../../styledComponent/heading/TitleLargeBold';
-import BodySmallMedium from '../../styledComponent/heading/BodySmallMedium';
-import Footer from '../../components/common/Footer';
+import TitleLargeMedium from '../../styledComponent/heading/TitleLargeBold';
+import BodySmallBold from '../../styledComponent/heading/BodySmallMedium';
 
 const SmallImageDiv = styled.div<{ $URL: string }>`
   width: 28px;


### PR DESCRIPTION
1. interface Notice 겹침으로 인한 에러
- 크루에서 사용하는 notice는 CrewNotice로 변경

2. 홈 디자인 변경으로 인한 import 에러
- 주혁님이 작성하신 내용 기준으로 변경

3. AxiosResponse import 누락으로 인한 에러
- import문 추가